### PR TITLE
up fin.erb to support non-ascii

### DIFF
--- a/app/views/csv_imports/finalize.html.erb
+++ b/app/views/csv_imports/finalize.html.erb
@@ -25,8 +25,8 @@
       <tbody>
         <% @csv_rows[0].each_with_index do |value, index| %>
           <tr class="<%= cycle('odd', 'even') %> issue child parent">
-				    <td> <%= value %> </td>
-				    <td> <%= @csv_rows[1][index] %> </td>
+				    <td> <%= value.force_encoding("utf-8") %> </td>
+				    <td> <%= @csv_rows[1][index].force_encoding("utf-8") %> </td>
 				    <% @options = params[:options][index] if params[:import] %>
 				    <td>
 				      <%= select_tag :options, options_for_select(@query, :selected => @options), {:name => "options[]", :prompt => "No Match (Skip)"} 


### PR DESCRIPTION
if csv file has non-ascii word, the plugin will show error.

I find finalize.html.erb do the bug,and I add `.force_encoding("utf-8")`
